### PR TITLE
115 get personal data from cache to UI

### DIFF
--- a/app/src/main/java/cy/volleybolley/core/domain/VolleyFeature.kt
+++ b/app/src/main/java/cy/volleybolley/core/domain/VolleyFeature.kt
@@ -7,4 +7,5 @@ object VolleyFeature {
     const val IS_UPCOMING_GAMES_AVAILABLE = false
     const val IS_GAME_INVITES_AVAILABLE = false
     const val IS_GENDER_CHANGE_AVAILABLE = false
+    const val IS_SUPPORT_AVAILABLE = false
 }

--- a/app/src/main/java/cy/volleybolley/core/domain/VolleyFeature.kt
+++ b/app/src/main/java/cy/volleybolley/core/domain/VolleyFeature.kt
@@ -6,4 +6,5 @@ object VolleyFeature {
     const val IS_AUTH_BY_PHONE_AVAILABLE = true
     const val IS_UPCOMING_GAMES_AVAILABLE = false
     const val IS_GAME_INVITES_AVAILABLE = false
+    const val IS_GENDER_CHANGE_AVAILABLE = false
 }

--- a/app/src/main/java/cy/volleybolley/core/presentation/ui/model/VolleyMocks.kt
+++ b/app/src/main/java/cy/volleybolley/core/presentation/ui/model/VolleyMocks.kt
@@ -8,18 +8,11 @@ import cy.volleybolley.games.domain.model.entity.Team
 import cy.volleybolley.games.domain.model.event.tournament.TournamentDetails
 import cy.volleybolley.profile.domain.model.Payment
 import cy.volleybolley.profile.domain.model.PaymentType
-import cy.volleybolley.profile.domain.model.PersonalData
 import cy.volleybolley.profile.presentation.ui.screens.playerprofile.model.PlayerActivityTemp
 import cy.volleybolley.profile.presentation.ui.screens.playerprofile.model.PlayerDetailTemp
 import cy.volleybolley.profile.presentation.ui.screens.players.model.PlayerTemp
-import cy.volleybolley.referencedata.domain.model.City
-import cy.volleybolley.referencedata.domain.model.Country
 
 object VolleyMocks {
-    const val USER_NAME = "User"
-    const val USER_SURNAME = "Userovich"
-    const val USER_AVATAR = "https://cdn.fishki.net/upload/post/2021/03/29/3682461/gallery/tn/" +
-        "wil-hughes-troll-face.jpg"
     const val USER_LEVEL = "PRO"
 
     const val MOCK_FAQ = "# Registration\n" +
@@ -68,28 +61,6 @@ object VolleyMocks {
     private const val PLAYER_6 = "Julia Petrova"
     private const val PLAYER_7 = "Tatiana Kalinina"
     private const val PLAYER_8 = "Artem Artemov"
-
-    val mockPersonalData = PersonalData(
-        firstName = USER_NAME,
-        lastName = USER_SURNAME,
-        gender = "MALE",
-        birthDate = "1987-03-23",
-        level = "LIGHT",
-        countryId = 0,
-        cityId = 1,
-        avatar = USER_AVATAR
-    )
-
-    val countries = listOf(
-        Country(
-            id = 0,
-            name = "Thailand",
-            cities = listOf(
-                City(id = 0, name = "Koh Phangan"),
-                City(id = 1, name = "Koh Samui")
-            )
-        )
-    )
 
     val mockLocation = Location(
         longitude = 7.866269,

--- a/app/src/main/java/cy/volleybolley/profile/di/ProfileModule.kt
+++ b/app/src/main/java/cy/volleybolley/profile/di/ProfileModule.kt
@@ -9,7 +9,7 @@ import cy.volleybolley.profile.data.network.model.ProfileResponse
 import cy.volleybolley.profile.domain.DeleteAvatarUseCase
 import cy.volleybolley.profile.domain.DeleteProfileUseCase
 import cy.volleybolley.profile.domain.GetPaymentsUseCase
-import cy.volleybolley.profile.domain.GetPersonalDataUseCase
+import cy.volleybolley.profile.domain.GetPersonalDataFromServerUseCase
 import cy.volleybolley.profile.domain.UpdateAvatarUseCase
 import cy.volleybolley.profile.domain.UpdatePaymentsUseCase
 import cy.volleybolley.profile.domain.UpdatePersonalDataUseCase
@@ -43,7 +43,7 @@ val profileModule = module {
     }
 
     // Domain
-    factory { GetPersonalDataUseCase(repository = get()) }
+    factory { GetPersonalDataFromServerUseCase(repository = get()) }
     factory { GetPaymentsUseCase(repository = get()) }
     factory { UpdatePersonalDataUseCase(repository = get()) }
     factory { UpdatePaymentsUseCase(repository = get()) }

--- a/app/src/main/java/cy/volleybolley/profile/domain/GetPersonalDataFromServerUseCase.kt
+++ b/app/src/main/java/cy/volleybolley/profile/domain/GetPersonalDataFromServerUseCase.kt
@@ -5,7 +5,7 @@ import cy.volleybolley.core.domain.model.VolleyResult
 import cy.volleybolley.profile.domain.api.ProfileRepository
 import cy.volleybolley.profile.domain.model.PersonalData
 
-class GetPersonalDataUseCase(
+class GetPersonalDataFromServerUseCase(
     private val repository: ProfileRepository,
 ) {
     suspend fun execute(): VolleyResult<PersonalData, ErrorType> {

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
@@ -1,5 +1,6 @@
 package cy.volleybolley.profile.presentation.ui.screens.personaldata
 
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -17,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -34,6 +36,7 @@ import cy.volleybolley.core.presentation.ui.component.VolleyAvatar
 import cy.volleybolley.core.presentation.ui.component.VolleyButton
 import cy.volleybolley.core.presentation.ui.model.VolleyColor
 import cy.volleybolley.core.presentation.ui.model.VolleyText
+import cy.volleybolley.core.presentation.ui.navigation.ChangePhotoRoute
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.CitySelect
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.CountrySelect
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.DateSelect
@@ -55,17 +58,23 @@ fun PersonalDataScreen(
     viewModel.handleBackAvatar()
     val state = viewModel.uiState.collectAsStateWithLifecycle().value
     val effect = viewModel.uiEffect.collectAsStateWithLifecycle(null).value
+    val context = LocalContext.current
 
     LaunchedEffect(effect) {
         when (effect) {
             is PersonalDataScreenEffect.NavigateFromPersonalDataScreen -> {
                 when (val route = effect.route) {
-                    is cy.volleybolley.core.presentation.ui.navigation.ChangePhotoRoute -> {
+                    is ChangePhotoRoute -> {
                         onNavigateToChangePhoto(route.avatarUrl)
                     }
                     else -> onNavigateBack()
                 }
             }
+
+            is PersonalDataScreenEffect.ShowToast -> {
+                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+            }
+
             null -> {}
         }
     }
@@ -229,7 +238,9 @@ private fun ChangeFieldsBlock(
 
         item {
             VolleyTextFieldGradient.GradientSpinner(
-                modifier = Modifier.fillMaxWidth().padding(bottom = 64.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 64.dp),
                 selectedItem = state.selectedCity,
                 itemList = state.cityList,
                 getTextByItem = { it?.name ?: "" },

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
@@ -170,9 +170,7 @@ private fun ChangeFieldsBlock(
         }
 
         item {
-            Spacer(Modifier.height(14.dp))
-            PersonalDataDivider()
-            Spacer(Modifier.height(16.dp))
+            PersonalDataDivider(modifier = Modifier.padding(bottom = 16.dp, top = 14.dp))
         }
 
         item {
@@ -198,13 +196,11 @@ private fun ChangeFieldsBlock(
         }
 
         item {
-            Spacer(Modifier.height(16.dp))
-            PersonalDataDivider()
-            Spacer(Modifier.height(16.dp))
+            PersonalDataDivider(modifier = Modifier.padding(vertical = 16.dp))
         }
 
         item {
-            PersonalDataTextMark(stringResource(R.string.date_of_bith))
+            PersonalDataTextMark(stringResource(R.string.date_of_birth))
             Spacer(Modifier.height(8.dp))
 
             VolleyTextFieldAttribute.DatePickerField(
@@ -214,9 +210,7 @@ private fun ChangeFieldsBlock(
         }
 
         item {
-            Spacer(Modifier.height(16.dp))
-            PersonalDataDivider()
-            Spacer(Modifier.height(16.dp))
+            PersonalDataDivider(modifier = Modifier.padding(vertical = 16.dp))
         }
 
         item {
@@ -231,9 +225,7 @@ private fun ChangeFieldsBlock(
         }
 
         item {
-            Spacer(Modifier.height(16.dp))
-            PersonalDataDivider()
-            Spacer(Modifier.height(16.dp))
+            PersonalDataDivider(modifier = Modifier.padding(vertical = 16.dp))
         }
 
         item {
@@ -252,9 +244,11 @@ private fun ChangeFieldsBlock(
 }
 
 @Composable
-private fun PersonalDataDivider() {
+private fun PersonalDataDivider(
+    modifier: Modifier = Modifier
+) {
     VolleySimpleComponent.DividerLine(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
     )
 }

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cy.volleybolley.R
+import cy.volleybolley.core.domain.VolleyFeature
 import cy.volleybolley.core.presentation.ui.VolleyContainersRootTransparent
 import cy.volleybolley.core.presentation.ui.VolleySimpleComponent
 import cy.volleybolley.core.presentation.ui.VolleyTextFieldAttribute
@@ -169,14 +170,22 @@ private fun ChangeFieldsBlock(
             PersonalDataTextMark(stringResource(R.string.gender))
             Spacer(Modifier.height(8.dp))
 
-            VolleyButton.SingleChoiceButtonGroup(
-                items = listOf(GenderType.MALE, GenderType.FEMALE),
-                selected = GenderType.getById(state.genderId),
-                label = { it.displayText },
-                modifier = Modifier,
-                paddingValues = PaddingValues(10.dp),
-                onSelect = { eventCallback(GenderSelect(it.id)) }
-            )
+            if (VolleyFeature.IS_GENDER_CHANGE_AVAILABLE) {
+                VolleyButton.SingleChoiceButtonGroup(
+                    items = listOf(GenderType.MALE, GenderType.FEMALE),
+                    selected = GenderType.getById(state.genderId),
+                    label = { it.displayText },
+                    modifier = Modifier,
+                    paddingValues = PaddingValues(10.dp),
+                    onSelect = { eventCallback(GenderSelect(it.id)) }
+                )
+            } else {
+                VolleyButton.ActiveGradientButton(
+                    modifier = Modifier,
+                    text = GenderType.getById(state.genderId).displayText,
+                    onClick = {}
+                )
+            }
         }
 
         item {
@@ -321,7 +330,7 @@ private fun PreviewPersonalDataScreen() {
                 .background(VolleyColor.TurquoiseDark)
         ) {
             PersonalDataScreen(
-                state = PersonalDataScreenState(),
+                state = PersonalDataScreenState(genderId = 1),
                 eventCallback = { }
             )
         }

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
@@ -11,8 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -21,6 +20,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -98,96 +98,135 @@ private fun PersonalDataScreen(
             )
             Spacer(Modifier.height(8.dp))
 
-            Column(Modifier.verticalScroll(rememberScrollState())) {
-                Spacer(Modifier.height(8.dp))
-                AvatarBlock(
-                    modifier = Modifier.fillMaxWidth(),
-                    avatarString = state.avatar,
-                    onIconClick = { eventCallback(OnAvatarEditClick) }
-                )
+            ChangeFieldsBlock(
+                modifier = Modifier,
+                state = state,
+                eventCallback = eventCallback
+            )
+        }
 
-                Spacer(Modifier.height(8.dp))
-                PersonalDataTextMark(stringResource(R.string.name))
-                Spacer(Modifier.height(8.dp))
+        VolleyButton.ActiveButton(
+            enabled = state.buttonEnabled,
+            text = stringResource(R.string.update),
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .padding(20.dp)
+                .height(44.dp)
+        ) { eventCallback(OnUpdateButtonClick) }
+    }
+}
 
-                VolleyTextFieldGradient.SimpleGradientTextField(
-                    hint = stringResource(R.string.name),
-                    text = state.name,
-                    actionToTransferContent = { eventCallback(NameChanged(it)) }
-                )
+@Composable
+private fun ChangeFieldsBlock(
+    modifier: Modifier = Modifier,
+    state: PersonalDataScreenState,
+    eventCallback: (PersonalDataScreenEvent) -> Unit,
+) {
+    LazyColumn(
+        modifier = modifier
+    ) {
+        item {
+            Spacer(Modifier.height(8.dp))
+            AvatarBlock(
+                modifier = Modifier.fillMaxWidth(),
+                avatarString = state.avatar,
+                onIconClick = { eventCallback(OnAvatarEditClick) }
+            )
+        }
 
-                Spacer(Modifier.height(14.dp))
-                PersonalDataTextMark(stringResource(R.string.surname))
-                Spacer(Modifier.height(8.dp))
+        item {
+            Spacer(Modifier.height(8.dp))
+            PersonalDataTextMark(stringResource(R.string.name))
+            Spacer(Modifier.height(8.dp))
 
-                VolleyTextFieldGradient.SimpleGradientTextField(
-                    hint = stringResource(R.string.surname),
-                    text = state.surname,
-                    actionToTransferContent = { eventCallback(SurnameChanged(it)) }
-                )
+            VolleyTextFieldGradient.SimpleGradientTextField(
+                hint = stringResource(R.string.name),
+                text = state.name,
+                actionToTransferContent = { eventCallback(NameChanged(it)) }
+            )
+        }
 
-                Spacer(Modifier.height(14.dp))
-                PersonalDataDivider()
-                Spacer(Modifier.height(16.dp))
-                PersonalDataTextMark(stringResource(R.string.gender))
-                Spacer(Modifier.height(8.dp))
+        item {
+            Spacer(Modifier.height(14.dp))
+            PersonalDataTextMark(stringResource(R.string.surname))
+            Spacer(Modifier.height(8.dp))
 
-                VolleyButton.SingleChoiceButtonGroup(
-                    items = listOf(GenderType.MALE, GenderType.FEMALE),
-                    selected = GenderType.getById(state.genderId),
-                    label = { it.displayText },
-                    modifier = Modifier,
-                    paddingValues = PaddingValues(10.dp),
-                    onSelect = { eventCallback(GenderSelect(it.id)) }
-                )
+            VolleyTextFieldGradient.SimpleGradientTextField(
+                hint = stringResource(R.string.surname),
+                text = state.surname,
+                actionToTransferContent = { eventCallback(SurnameChanged(it)) }
+            )
+        }
 
-                Spacer(Modifier.height(16.dp))
-                PersonalDataDivider()
-                Spacer(Modifier.height(16.dp))
-                PersonalDataTextMark(stringResource(R.string.date_of_bith))
-                Spacer(Modifier.height(8.dp))
+        item {
+            Spacer(Modifier.height(14.dp))
+            PersonalDataDivider()
+            Spacer(Modifier.height(16.dp))
+        }
 
-                VolleyTextFieldAttribute.DatePickerField(
-                    inputDate = state.dateOfBirthMillis,
-                    actionForSaveDate = { eventCallback(DateSelect(it)) }
-                )
+        item {
+            PersonalDataTextMark(stringResource(R.string.gender))
+            Spacer(Modifier.height(8.dp))
 
-                Spacer(Modifier.height(16.dp))
-                PersonalDataDivider()
-                Spacer(Modifier.height(16.dp))
+            VolleyButton.SingleChoiceButtonGroup(
+                items = listOf(GenderType.MALE, GenderType.FEMALE),
+                selected = GenderType.getById(state.genderId),
+                label = { it.displayText },
+                modifier = Modifier,
+                paddingValues = PaddingValues(10.dp),
+                onSelect = { eventCallback(GenderSelect(it.id)) }
+            )
+        }
 
-                VolleyTextFieldGradient.GradientSpinner(
-                    modifier = Modifier.fillMaxWidth(),
-                    selectedItem = state.selectedCountry,
-                    itemList = state.countryList,
-                    getTextByItem = { it?.name ?: "" },
-                    hint = stringResource(id = R.string.your_country),
-                    onItemSelect = { country, _ -> eventCallback(CountrySelect(country!!)) }
-                )
+        item {
+            Spacer(Modifier.height(16.dp))
+            PersonalDataDivider()
+            Spacer(Modifier.height(16.dp))
+        }
 
-                Spacer(Modifier.height(16.dp))
-                PersonalDataDivider()
-                Spacer(Modifier.height(16.dp))
+        item {
+            PersonalDataTextMark(stringResource(R.string.date_of_bith))
+            Spacer(Modifier.height(8.dp))
 
-                VolleyTextFieldGradient.GradientSpinner(
-                    modifier = Modifier.fillMaxWidth(),
-                    selectedItem = state.selectedCity,
-                    itemList = state.cityList,
-                    getTextByItem = { it?.name ?: "" },
-                    hint = stringResource(id = R.string.your_city),
-                    onItemSelect = { city, _ -> eventCallback(CitySelect(city!!)) }
-                )
+            VolleyTextFieldAttribute.DatePickerField(
+                inputDate = state.dateOfBirthMillis,
+                actionForSaveDate = { eventCallback(DateSelect(it)) }
+            )
+        }
 
-                Spacer(Modifier.height(16.dp))
+        item {
+            Spacer(Modifier.height(16.dp))
+            PersonalDataDivider()
+            Spacer(Modifier.height(16.dp))
+        }
 
-                VolleyButton.ActiveButton(
-                    enabled = state.buttonEnabled,
-                    text = stringResource(R.string.update),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(44.dp)
-                ) { eventCallback(OnUpdateButtonClick) }
-            }
+        item {
+            VolleyTextFieldGradient.GradientSpinner(
+                modifier = Modifier.fillMaxWidth(),
+                selectedItem = state.selectedCountry,
+                itemList = state.countryList,
+                getTextByItem = { it?.name ?: "" },
+                hint = stringResource(id = R.string.your_country),
+                onItemSelect = { country, _ -> eventCallback(CountrySelect(country!!)) }
+            )
+        }
+
+        item {
+            Spacer(Modifier.height(16.dp))
+            PersonalDataDivider()
+            Spacer(Modifier.height(16.dp))
+        }
+
+        item {
+            VolleyTextFieldGradient.GradientSpinner(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 64.dp),
+                selectedItem = state.selectedCity,
+                itemList = state.cityList,
+                getTextByItem = { it?.name ?: "" },
+                hint = stringResource(id = R.string.your_city),
+                onItemSelect = { city, _ -> eventCallback(CitySelect(city!!)) }
+            )
         }
     }
 }
@@ -271,7 +310,7 @@ private fun PreviewAvatarBlock() {
     }
 }
 
-@Preview(showSystemUi = false, heightDp = 1000)
+@Preview(showBackground = true, showSystemUi = true, device = Devices.PIXEL_9_PRO)
 @Composable
 private fun PreviewPersonalDataScreen() {
     VolleyContainersRootTransparent.Root {

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -67,6 +66,7 @@ fun PersonalDataScreen(
                     is ChangePhotoRoute -> {
                         onNavigateToChangePhoto(route.avatarUrl)
                     }
+
                     else -> onNavigateBack()
                 }
             }
@@ -103,10 +103,11 @@ private fun PersonalDataScreen(
         ) {
             VolleySimpleComponent.TitleWithBackArrow(
                 title = stringResource(R.string.personal_data),
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .padding(bottom = 8.dp)
+                    .fillMaxWidth(),
                 onBackClick = { eventCallback(OnBackFromPersonalDataClick) }
             )
-            Spacer(Modifier.height(8.dp))
 
             ChangeFieldsBlock(
                 modifier = Modifier,
@@ -137,18 +138,20 @@ private fun ChangeFieldsBlock(
         modifier = modifier
     ) {
         item {
-            Spacer(Modifier.height(8.dp))
             AvatarBlock(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .fillMaxWidth(),
                 avatarString = state.avatar,
                 onIconClick = { eventCallback(OnAvatarEditClick) }
             )
         }
 
         item {
-            Spacer(Modifier.height(8.dp))
-            PersonalDataTextMark(stringResource(R.string.name))
-            Spacer(Modifier.height(8.dp))
+            PersonalDataTextMark(
+                modifier = Modifier.padding(vertical = 8.dp),
+                text = stringResource(R.string.name)
+            )
 
             VolleyTextFieldGradient.SimpleGradientTextField(
                 hint = stringResource(R.string.name),
@@ -158,9 +161,10 @@ private fun ChangeFieldsBlock(
         }
 
         item {
-            Spacer(Modifier.height(14.dp))
-            PersonalDataTextMark(stringResource(R.string.surname))
-            Spacer(Modifier.height(8.dp))
+            PersonalDataTextMark(
+                modifier = Modifier.padding(top = 14.dp, bottom = 8.dp),
+                text = stringResource(R.string.surname)
+            )
 
             VolleyTextFieldGradient.SimpleGradientTextField(
                 hint = stringResource(R.string.surname),
@@ -174,8 +178,10 @@ private fun ChangeFieldsBlock(
         }
 
         item {
-            PersonalDataTextMark(stringResource(R.string.gender))
-            Spacer(Modifier.height(8.dp))
+            PersonalDataTextMark(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(R.string.gender)
+            )
 
             if (VolleyFeature.IS_GENDER_CHANGE_AVAILABLE) {
                 VolleyButton.SingleChoiceButtonGroup(
@@ -200,8 +206,10 @@ private fun ChangeFieldsBlock(
         }
 
         item {
-            PersonalDataTextMark(stringResource(R.string.date_of_birth))
-            Spacer(Modifier.height(8.dp))
+            PersonalDataTextMark(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(R.string.date_of_birth)
+            )
 
             VolleyTextFieldAttribute.DatePickerField(
                 inputDate = state.dateOfBirthMillis,
@@ -255,6 +263,7 @@ private fun PersonalDataDivider(
 
 @Composable
 private fun PersonalDataTextMark(
+    modifier: Modifier = Modifier,
     text: String,
 ) {
     VolleyText.BodyBold(
@@ -262,7 +271,7 @@ private fun PersonalDataTextMark(
         color = VolleyColor.White,
         textAlign = TextAlign.Start,
         maxLines = 1,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
     )
 }
 

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreenEffect.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreenEffect.kt
@@ -5,4 +5,5 @@ import cy.volleybolley.core.presentation.ui.navigation.NavMap
 
 sealed interface PersonalDataScreenEffect : UiEffect {
     data class NavigateFromPersonalDataScreen(val route: NavMap?) : PersonalDataScreenEffect
+    class ShowToast(val message: String) : PersonalDataScreenEffect
 }

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreenViewModel.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreenViewModel.kt
@@ -130,8 +130,8 @@ class PersonalDataScreenViewModel(
 
     private fun handleAndSetOriginStateOnInit(
         personalData: PersonalData?,
-        countries: List<Country>? = null)
-        : PersonalDataScreenState {
+        countries: List<Country>? = null
+    ): PersonalDataScreenState {
         originState = personalData.withCountriesToState(countries)
         return originState
     }

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreenViewModel.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreenViewModel.kt
@@ -4,7 +4,6 @@ import cy.volleybolley.auth.domain.api.usecase.GetPersonalDataUseCase
 import cy.volleybolley.core.domain.model.onFailure
 import cy.volleybolley.core.domain.model.onSuccess
 import cy.volleybolley.core.presentation.base.BaseViewModel
-import cy.volleybolley.core.presentation.ui.model.VolleyUiUtil
 import cy.volleybolley.core.presentation.ui.navigation.ChangePhotoRoute
 import cy.volleybolley.core.util.VolleyLog
 import cy.volleybolley.profile.domain.UpdatePersonalDataUseCase
@@ -20,8 +19,8 @@ import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalData
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.OnBackFromPersonalDataClick
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.OnUpdateButtonClick
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.SurnameChanged
+import cy.volleybolley.profile.presentation.ui.screens.personaldata.mapper.withCountriesToState
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.model.BackAvatarHolder
-import cy.volleybolley.profile.presentation.ui.screens.personaldata.model.GenderType
 import cy.volleybolley.referencedata.domain.api.GetCountriesUseCase
 import cy.volleybolley.referencedata.domain.model.Country
 import kotlinx.coroutines.flow.update
@@ -132,50 +131,12 @@ class PersonalDataScreenViewModel(
         personalData: PersonalData?,
         countries: List<Country>? = null
     ): PersonalDataScreenState {
-        originState = personalData.withCountriesToState(countries)
+        originState = personalData
+            .withCountriesToState(
+                countries = countries,
+                stateForButtonEnabledFlag = originState
+            )
         return originState
-    }
-
-    private fun PersonalData?.withCountriesToState(countries: List<Country>? = null): PersonalDataScreenState {
-        val selectedCountryById = countries?.find { it.id == this?.countryId }
-        return PersonalDataScreenState(
-            avatar = this?.avatar,
-            name = this?.firstName ?: "",
-            surname = this?.lastName ?: "",
-            levelHolder = this?.level ?: "",
-            genderId = this?.gender?.let {
-                GenderType.getIdByStringValue(it)
-            } ?: 0,
-            dateOfBirthMillis = this?.birthDate?.let {
-                VolleyUiUtil.convertTextDateToMillis(
-                    VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,
-                    it
-                )
-            },
-            selectedCountry = selectedCountryById,
-            selectedCity = selectedCountryById?.cities?.find { it.id == this?.cityId },
-            countryList = countries ?: emptyList(),
-            cityList = selectedCountryById?.cities ?: emptyList(),
-            buttonEnabled = originState.buttonEnabled
-        )
-    }
-
-    private fun PersonalDataScreenState.toPersonalData(): PersonalData {
-        return PersonalData(
-            firstName = name,
-            lastName = surname,
-            gender = GenderType.getNameValueById(genderId),
-            birthDate = dateOfBirthMillis?.let {
-                VolleyUiUtil.convertMillisToTextDate(
-                    VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,
-                    it
-                )
-            } ?: "2000-12-31",
-            level = levelHolder,
-            countryId = selectedCountry?.id ?: -1,
-            cityId = selectedCity?.id ?: -1,
-            avatar = avatar
-        )
     }
 
     private fun checkStateForButtonEnabled(newState: PersonalDataScreenState): PersonalDataScreenState {

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreenViewModel.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/PersonalDataScreenViewModel.kt
@@ -1,14 +1,16 @@
 package cy.volleybolley.profile.presentation.ui.screens.personaldata
 
+import cy.volleybolley.auth.domain.api.usecase.GetPersonalDataUseCase
+import cy.volleybolley.core.domain.model.onFailure
 import cy.volleybolley.core.domain.model.onSuccess
 import cy.volleybolley.core.presentation.base.BaseViewModel
-import cy.volleybolley.core.presentation.ui.model.VolleyMocks
 import cy.volleybolley.core.presentation.ui.model.VolleyUiUtil
 import cy.volleybolley.core.presentation.ui.navigation.ChangePhotoRoute
-import cy.volleybolley.profile.domain.GetPersonalDataUseCase
+import cy.volleybolley.core.util.VolleyLog
 import cy.volleybolley.profile.domain.UpdatePersonalDataUseCase
 import cy.volleybolley.profile.domain.model.PersonalData
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEffect.NavigateFromPersonalDataScreen
+import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEffect.ShowToast
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.CitySelect
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.CountrySelect
 import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenEvent.DateSelect
@@ -35,14 +37,7 @@ class PersonalDataScreenViewModel(
     private var originState: PersonalDataScreenState = uiState.value
 
     init {
-        // getCountriesList() - сперва подтягиваем страны в originState
-        originState = originState.copy(countryList = VolleyMocks.countries)
-
-        // getState() - затем сохраняем персональные данные в originState
-        launchSafe(getErrorLogMessage = { "PersonalDataScreen >> init: ${it.message}" }) {
-            originState = VolleyMocks.mockPersonalData.addToState()
-            uiStateMutable.update { originState }
-        }
+        initScreenState()
     }
 
     override fun obtainEvent(event: PersonalDataScreenEvent) {
@@ -85,7 +80,7 @@ class PersonalDataScreenViewModel(
 
     fun handleBackAvatar() {
         backAvatarHolder.getAvatarChanges()?.let { avatarValue ->
-            val newAvatar = if (avatarValue.isEmpty()) null else avatarValue
+            val newAvatar = avatarValue.ifEmpty { null }
             originState = originState.copy(avatar = newAvatar)
             uiStateMutable.update { it.copy(avatar = newAvatar) }
             backAvatarHolder.clearBackAvatar()
@@ -93,20 +88,7 @@ class PersonalDataScreenViewModel(
     }
 
     private fun onUpdateClick() {
-        launchSafe(
-            getErrorLogMessage = { "PersonalDataScreen >> Update button: ${it.message}" },
-            block = {
-                val newPersonalData = uiState.value.toPersonalData()
-                updatePersonalDataUseCase.execute(newPersonalData)
-                    .onSuccess {
-                        getPersonalDataUseCase.execute()
-                            .onSuccess { personalData ->
-                                originState = personalData.addToState()
-                                uiStateMutable.update { originState }
-                            }
-                    }
-            }
-        )
+        // next task
     }
 
     private fun onCountrySelected(country: Country) {
@@ -121,22 +103,59 @@ class PersonalDataScreenViewModel(
         }
     }
 
-    private fun PersonalData.addToState(): PersonalDataScreenState {
-        val countryById = originState.countryList.find { it.id == countryId }
+    private fun initScreenState() {
+        launchSafe(
+            getErrorLogMessage = {
+                "PersonalDataScreen >>> initScreenState() >>> countries + personal data: ${it.message}"
+            },
+            onError = { sendUiEffect(ShowToast("Data init fail: ${it.message}")) }
+        ) {
+            val personalData = getPersonalDataUseCase.execute()
+            getCountriesUseCase.execute()
+                .onSuccess { countries ->
+                    uiStateMutable.update {
+                        handleAndSetOriginStateOnInit(personalData, countries)
+                    }
+                }
+                .onFailure { error ->
+                    VolleyLog.e(tag, "PersonalDataScreen >>> getCountriesUseCase(): $error")
+                    sendUiEffect(ShowToast("Get countries failed"))
+                    uiStateMutable.update {
+                        handleAndSetOriginStateOnInit(personalData)
+                    }
+                }
+
+        }
+    }
+
+    private fun handleAndSetOriginStateOnInit(
+        personalData: PersonalData?,
+        countries: List<Country>? = null)
+        : PersonalDataScreenState {
+        originState = personalData.withCountriesToState(countries)
+        return originState
+    }
+
+    private fun PersonalData?.withCountriesToState(countries: List<Country>? = null): PersonalDataScreenState {
+        val selectedCountryById = countries?.find { it.id == this?.countryId }
         return PersonalDataScreenState(
-            avatar = avatar,
-            name = firstName,
-            surname = lastName,
-            levelHolder = level,
-            genderId = GenderType.Companion.getIdByStringValue(gender),
-            dateOfBirthMillis = VolleyUiUtil.convertTextDateToMillis(
-                VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,
-                birthDate
-            ),
-            selectedCountry = countryById,
-            selectedCity = countryById?.cities?.find { it.id == cityId },
-            countryList = originState.countryList,
-            cityList = countryById?.cities ?: emptyList(),
+            avatar = this?.avatar,
+            name = this?.firstName ?: "",
+            surname = this?.lastName ?: "",
+            levelHolder = this?.level ?: "",
+            genderId = this?.gender?.let {
+                GenderType.getIdByStringValue(it)
+            } ?: 0,
+            dateOfBirthMillis = this?.birthDate?.let {
+                VolleyUiUtil.convertTextDateToMillis(
+                    VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,
+                    it
+                )
+            },
+            selectedCountry = selectedCountryById,
+            selectedCity = selectedCountryById?.cities?.find { it.id == this?.cityId },
+            countryList = countries ?: emptyList(),
+            cityList = selectedCountryById?.cities ?: emptyList(),
             buttonEnabled = originState.buttonEnabled
         )
     }
@@ -145,7 +164,7 @@ class PersonalDataScreenViewModel(
         return PersonalData(
             firstName = name,
             lastName = surname,
-            gender = GenderType.Companion.getNameValueById(genderId),
+            gender = GenderType.getNameValueById(genderId),
             birthDate = dateOfBirthMillis?.let {
                 VolleyUiUtil.convertMillisToTextDate(
                     VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/mapper/PersonalDataUiMapper.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/mapper/PersonalDataUiMapper.kt
@@ -1,0 +1,52 @@
+package cy.volleybolley.profile.presentation.ui.screens.personaldata.mapper
+
+import cy.volleybolley.core.presentation.ui.model.VolleyUiUtil
+import cy.volleybolley.profile.domain.model.PersonalData
+import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenState
+import cy.volleybolley.profile.presentation.ui.screens.personaldata.model.GenderType
+import cy.volleybolley.referencedata.domain.model.Country
+
+fun PersonalData?.withCountriesToState(
+    countries: List<Country>? = null,
+    stateForButtonEnabledFlag: PersonalDataScreenState,
+): PersonalDataScreenState {
+    val selectedCountryById = countries?.find { it.id == this?.countryId }
+    return PersonalDataScreenState(
+        avatar = this?.avatar,
+        name = this?.firstName ?: "",
+        surname = this?.lastName ?: "",
+        levelHolder = this?.level ?: "",
+        genderId = this?.gender?.let {
+            GenderType.getIdByStringValue(it)
+        } ?: 0,
+        dateOfBirthMillis = this?.birthDate?.let {
+            VolleyUiUtil.convertTextDateToMillis(
+                VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,
+                it
+            )
+        },
+        selectedCountry = selectedCountryById,
+        selectedCity = selectedCountryById?.cities?.find { it.id == this?.cityId },
+        countryList = countries ?: emptyList(),
+        cityList = selectedCountryById?.cities ?: emptyList(),
+        buttonEnabled = stateForButtonEnabledFlag.buttonEnabled
+    )
+}
+
+private fun PersonalDataScreenState.toPersonalData(): PersonalData {
+    return PersonalData(
+        firstName = name,
+        lastName = surname,
+        gender = GenderType.getNameValueById(genderId),
+        birthDate = dateOfBirthMillis?.let {
+            VolleyUiUtil.convertMillisToTextDate(
+                VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,
+                it
+            )
+        } ?: "1999-12-31",
+        level = levelHolder,
+        countryId = selectedCountry?.id ?: -1,
+        cityId = selectedCity?.id ?: -1,
+        avatar = avatar
+    )
+}

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/mapper/PersonalDataUiMapper.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/mapper/PersonalDataUiMapper.kt
@@ -1,0 +1,52 @@
+package cy.volleybolley.profile.presentation.ui.screens.personaldata.mapper
+
+import cy.volleybolley.core.presentation.ui.model.VolleyUiUtil
+import cy.volleybolley.profile.domain.model.PersonalData
+import cy.volleybolley.profile.presentation.ui.screens.personaldata.PersonalDataScreenState
+import cy.volleybolley.profile.presentation.ui.screens.personaldata.model.GenderType
+import cy.volleybolley.referencedata.domain.model.Country
+
+fun PersonalData?.withCountriesToState(
+    countries: List<Country>? = null,
+    stateForButtonEnabledFlag: PersonalDataScreenState,
+): PersonalDataScreenState {
+    val selectedCountryById = countries?.find { it.id == this?.countryId }
+    return PersonalDataScreenState(
+        avatar = this?.avatar,
+        name = this?.firstName ?: "",
+        surname = this?.lastName ?: "",
+        levelHolder = this?.level ?: "",
+        genderId = this?.gender?.let {
+            GenderType.getIdByStringValue(it)
+        } ?: 0,
+        dateOfBirthMillis = this?.birthDate?.let {
+            VolleyUiUtil.convertTextDateToMillis(
+                VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,
+                it
+            )
+        },
+        selectedCountry = selectedCountryById,
+        selectedCity = selectedCountryById?.cities?.find { it.id == this?.cityId },
+        countryList = countries ?: emptyList(),
+        cityList = selectedCountryById?.cities ?: emptyList(),
+        buttonEnabled = stateForButtonEnabledFlag.buttonEnabled
+    )
+}
+
+fun PersonalDataScreenState.toPersonalData(): PersonalData {
+    return PersonalData(
+        firstName = name,
+        lastName = surname,
+        gender = GenderType.getNameValueById(genderId),
+        birthDate = dateOfBirthMillis?.let {
+            VolleyUiUtil.convertMillisToTextDate(
+                VolleyUiUtil.DATE_OF_BIRTH_PATTERN_FOR_SERVER,
+                it
+            )
+        } ?: "1999-12-31",
+        level = levelHolder,
+        countryId = selectedCountry?.id ?: -1,
+        cityId = selectedCity?.id ?: -1,
+        avatar = avatar
+    )
+}

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/model/GenderType.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/personaldata/model/GenderType.kt
@@ -7,7 +7,7 @@ enum class GenderType(
 ) {
     MALE(1, "MALE", "Male"),
     FEMALE(2, "FEMALE", "Female"),
-    UNKNOWN(0, "", "");
+    UNKNOWN(0, "UNKNOWN", "Unknown");
 
     companion object {
         @JvmStatic

--- a/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/cy/volleybolley/profile/presentation/ui/screens/profile/ProfileScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cy.volleybolley.R
+import cy.volleybolley.core.domain.VolleyFeature
 import cy.volleybolley.core.presentation.RootContainerForPreview
 import cy.volleybolley.core.presentation.ui.VolleyContainersRootTransparent
 import cy.volleybolley.core.presentation.ui.VolleySimpleComponent
@@ -135,12 +136,14 @@ private fun ProfileScreen(
 
                     ProfileComponentDivider()
 
-                    ProfileComponent(
-                        painter = painterResource(R.drawable.ic_support),
-                        title = stringResource(R.string.profile_support_component),
-                    ) { eventCallback(OnSupportClick) }
+                    if (VolleyFeature.IS_SUPPORT_AVAILABLE) {
+                        ProfileComponent(
+                            painter = painterResource(R.drawable.ic_support),
+                            title = stringResource(R.string.profile_support_component),
+                        ) { eventCallback(OnSupportClick) }
 
-                    ProfileComponentDivider()
+                        ProfileComponentDivider()
+                    }
 
                     ProfileComponent(
                         painter = painterResource(R.drawable.ic_faq),

--- a/app/src/main/java/cy/volleybolley/registration/presentation/ui/screens/registration/RegistrationScreen.kt
+++ b/app/src/main/java/cy/volleybolley/registration/presentation/ui/screens/registration/RegistrationScreen.kt
@@ -276,7 +276,7 @@ private fun FillDateOfBirth(
 ) {
     Column(modifier = modifier) {
         VolleyText.BodyBold(
-            text = stringResource(id = R.string.date_of_bith),
+            text = stringResource(id = R.string.date_of_birth),
             color = VolleyColor.White
         )
         VolleyTextFieldAttribute.DatePickerField(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
     <string name="gender">Gender</string>
     <string name="male">Male</string>
     <string name="female">Female</string>
-    <string name="date_of_bith">Date of birth</string>
+    <string name="date_of_birth">Date of birth</string>
     <string name="level">Level</string>
     <string name="your_country">Your country</string>
     <string name="choose_your_location">Choose your location</string>


### PR DESCRIPTION
Реализовал привязку данных из кэша к UI экрана PersonalData. Моки снёс.

Из допов немного подправил UI:
- сделал поведение кнопки Update как на экране Регистрации
- убрал под фича-флаг изменение пола (сейчас просто показываем плашку)
- убрал под фича-флаг поле Support на общем экране Профиля

